### PR TITLE
Fixing ./build.js error

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "fs-extra": "*"
   },
   "dependencies": {
+    "node-sass-utils": "^1.1.2",
     "node-static": "^0.7.6"
   }
 }


### PR DESCRIPTION
Using Node v0.12.6, after an `npm install` I tried running `./build.js` but I received this error:

```
module.js:338
    throw err;
          ^
Error: Cannot find module 'node-sass-utils'
```

Adding `node-sass-utils` to package.json fixed the issue for me
